### PR TITLE
Support `gpt-4-1106-preview` model

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ export type supportModelType =
     | 'gpt-4-32k'
     | 'gpt-4-32k-0314'
     | 'gpt-4-32k-0613'
+    | 'gpt-4-1106-preview'
 
 interface MessageItem {
     name?: string
@@ -78,6 +79,7 @@ export class GPTTokens {
         'gpt-4-32k',
         'gpt-4-32k-0314',
         'gpt-4-32k-0613',
+        'gpt-4-1106-preview',
     ]
 
     public readonly model
@@ -123,6 +125,16 @@ export class GPTTokens {
     // gpt-4-32k
     // Completion: $0.12 / 1K tokens
     public readonly gpt4_32kCompletionTokenUnit = new Decimal(0.12).div(1000).toNumber()
+
+    // https://openai.com/pricing/
+    // gpt-4-1106-preview
+    // Prompt: $0.01 / 1K tokens
+    public readonly gpt4_turbo_previewPromptTokenUnit = new Decimal(0.01).div(1000).toNumber()
+
+    // https://openai.com/pricing/
+    // gpt-4-1106-preview
+    // Completion: $0.03 / 1K tokens
+    public readonly gpt4_turbo_previewCompletionTokenUnit = new Decimal(0.03).div(1000).toNumber()
 
     // Used USD
     public get usedUSD (): number {
@@ -178,6 +190,16 @@ export class GPTTokens {
 
             price = promptUSD.add(completionUSD).toNumber()
         }
+
+        if (this.model === 'gpt-4-1106-preview') {
+          const promptUSD = new Decimal(this.promptUsedTokens)
+            .mul(this.gpt4_turbo_previewPromptTokenUnit)
+          const completionUSD = new Decimal(this.completionUsedTokens)
+            .mul(this.gpt4_turbo_previewCompletionTokenUnit)
+
+          price = promptUSD.add(completionUSD).toNumber()
+        }
+
 
         return price
     }
@@ -261,6 +283,7 @@ export class GPTTokens {
             'gpt-4-32k',
             'gpt-4-32k-0314',
             'gpt-4-32k-0613',
+            'gpt-4-1106-preview'
         ].includes(model)) {
             tokens_per_message = 3
             tokens_per_name    = 1

--- a/index.ts
+++ b/index.ts
@@ -283,7 +283,7 @@ export class GPTTokens {
             'gpt-4-32k',
             'gpt-4-32k-0314',
             'gpt-4-32k-0613',
-            'gpt-4-1106-preview'
+            'gpt-4-1106-preview',
         ].includes(model)) {
             tokens_per_message = 3
             tokens_per_name    = 1


### PR DESCRIPTION
This PR aims to begin the work needed to support the new `gpt-4-1106-preview` GPT-4 Turbo preview model. The PR in this current state is incomplete since it will first require the [js-tiktoken](https://www.npmjs.com/package/js-tiktoken) dependency to support that model. That work within js-tiktoken is underway and can be tracked here: https://github.com/dqbd/tiktoken/pull/79

Once that is complete, then upgrading the dependency should resolve the type error in `getEncodingForModelCached` which currently fails due to `gpt-4-1106-preview` not being a supported model type. 

I was unsure about where to find the values for `tokens_per_message` and `tokens_per_name`, so I left those the same as their GPT-4 counterparts.